### PR TITLE
feat: display elegant spinner on Windows Terminal

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const frames = process.platform === 'win32' ?
+const frames = process.platform === 'win32' && !process.env.WT_SESSION ?
 	['-', '\\', '|', '/'] :
 	['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 


### PR DESCRIPTION
On `conhost.exe`, these characters were not supported. But on Windows Terminal, they are. The Windows Terminal adds the [`WT_SESSION`](https://github.com/microsoft/terminal/issues/840) environment variable, which allows to identify when it's used. Thanks to that, we can now display fancy figures on Windows.

This change updates the previous behavior by adding an additional check against the `WT_SESSION` environment variable, in order to allow these characters on the Windows Terminal.

![](https://i.imgur.com/24Jff2W.png)